### PR TITLE
apply callout style to workbench moderation block

### DIFF
--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5575,7 +5575,7 @@ Markup: templates/callouts-examples.html
 Style guide: Typography.7 Callouts & warnings
 */
 .callout, .callout--warning, .callout--calendar-event, [class^='callout--'],
-[class*=' callout--'] {
+[class*=' callout--'], div.workbench-info-block {
   margin: 1.6em 0.8em;
   padding: 1.2em 1.2em 1.2em 1.6em;
   border-radius: 1px;
@@ -5841,7 +5841,7 @@ Markup: templates/callouts-examples.html
 Style guide: Typography.7 Callouts & warnings
 */
 .callout, .callout--warning, .callout--calendar-event, [class^='callout--'],
-[class*=' callout--'] {
+[class*=' callout--'], div.workbench-info-block {
   margin: 1.6em 0.8em;
   padding: 1.2em 1.2em 1.2em 1.6em;
   border-radius: 1px;
@@ -5873,3 +5873,10 @@ Style guide: Typography.7 Callouts & warnings
   padding-bottom: 0.8em;
   background-color: #def4f9;
   border-left: none; }
+
+div.workbench-info-block {
+  padding-left: 1.2em;
+  border-left-width: 0.4em;
+  border-left-style: solid;
+  background-color: #fff;
+  border-left-color: #00bfe9; }

--- a/sass/modules/_workbench.scss
+++ b/sass/modules/_workbench.scss
@@ -1,0 +1,9 @@
+div.workbench-info-block {
+  @extend %base-callout;
+
+  padding-left: $base-spacing - $tiny-spacing;
+  border-left-width: $tiny-spacing;
+  border-left-style: solid;
+  background-color: #fff;
+  border-left-color: $info-colour;
+}

--- a/sass/ui-kit.scss
+++ b/sass/ui-kit.scss
@@ -2,3 +2,4 @@
 @import "vars";
 @import "../ui-kit/assets/sass/ui-kit.scss";
 @import "components/typography";
+@import "modules/workbench";


### PR DESCRIPTION
There is possibly an argument to update the module to get the callout--info class onto the block, however I've gone for the css only approach. It's a few extra lines of code so arguably not a big deal.