### PR TITLE
moving table style onto the table element

### DIFF
--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5804,6 +5804,24 @@ article h1:first-of-type, article .hero .site-title:first-of-type, .hero article
       width: 100%;
       border: none; }
 
+table {
+  width: 100%;
+  border-collapse: collapse; }
+  table tr:nth-child(even) {
+    background-color: #f0f3f5; }
+  table td,
+  table th {
+    border-bottom: solid 1px #bbbbbb;
+    padding: 0.4em;
+    text-align: left; }
+    @media screen and (min-width: 768px) {
+      table td,
+      table th {
+        padding: 0.8em;
+        font-size: initial; } }
+  table thead {
+    border-bottom: solid 2px #6e6e6e; }
+
 /*
 Callouts & warnings
 

--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -4907,22 +4907,22 @@ Style guide: Tables.1 Basic tables
 table {
   margin-bottom: 1.6em; }
 
-.content-table {
+.content-table, table {
   width: 100%;
   border-collapse: collapse; }
-  .content-table tr:nth-child(even) {
+  .content-table tr:nth-child(even), table tr:nth-child(even) {
     background-color: #f0f3f5; }
-  .content-table td,
-  .content-table th {
+  .content-table td, table td,
+  .content-table th, table th {
     border-bottom: solid 1px #bbbbbb;
     padding: 0.4em;
     text-align: left; }
     @media screen and (min-width: 768px) {
-      .content-table td,
-      .content-table th {
+      .content-table td, table td,
+      .content-table th, table th {
         padding: 0.8em;
         font-size: initial; } }
-  .content-table thead {
+  .content-table thead, table thead {
     border-bottom: solid 2px #6e6e6e; }
 
 /*
@@ -5803,24 +5803,6 @@ article h1:first-of-type, article .hero .site-title:first-of-type, .hero article
       height: 100%;
       width: 100%;
       border: none; }
-
-table {
-  width: 100%;
-  border-collapse: collapse; }
-  table tr:nth-child(even) {
-    background-color: #f0f3f5; }
-  table td,
-  table th {
-    border-bottom: solid 1px #bbbbbb;
-    padding: 0.4em;
-    text-align: left; }
-    @media screen and (min-width: 768px) {
-      table td,
-      table th {
-        padding: 0.8em;
-        font-size: initial; } }
-  table thead {
-    border-bottom: solid 2px #6e6e6e; }
 
 /*
 Callouts & warnings

--- a/sass/components/_tables.scss
+++ b/sass/components/_tables.scss
@@ -1,5 +1,3 @@
-// @TODO - this is shifting the .content-type selector onto the <table> element. We need to create a PR to get this implemented upstream
-
 table {
   @extend .content-table;
 }

--- a/sass/components/_tables.scss
+++ b/sass/components/_tables.scss
@@ -1,0 +1,26 @@
+// @TODO - this is shifting the .content-type selector onto the <table> element. We need to create a PR to get this implemented upstream
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+
+  tr:nth-child(even) {
+    background-color: $non-white;
+  }
+
+  td,
+  th {
+    border-bottom: solid 1px $light-grey;
+    padding: $tiny-spacing;
+    text-align: left;
+
+    @include media($tablet) {
+      padding: $small-spacing;
+      font-size: initial;
+    }
+  }
+
+  thead {
+    border-bottom: solid 2px $grey;
+  }
+}

--- a/sass/components/_tables.scss
+++ b/sass/components/_tables.scss
@@ -1,26 +1,5 @@
 // @TODO - this is shifting the .content-type selector onto the <table> element. We need to create a PR to get this implemented upstream
 
 table {
-  width: 100%;
-  border-collapse: collapse;
-
-  tr:nth-child(even) {
-    background-color: $non-white;
-  }
-
-  td,
-  th {
-    border-bottom: solid 1px $light-grey;
-    padding: $tiny-spacing;
-    text-align: left;
-
-    @include media($tablet) {
-      padding: $small-spacing;
-      font-size: initial;
-    }
-  }
-
-  thead {
-    border-bottom: solid 2px $grey;
-  }
+  @extend .content-table;
 }

--- a/sass/ui-kit.scss
+++ b/sass/ui-kit.scss
@@ -1,5 +1,5 @@
 // This file should be processed using SASS, and will compile to /css/styles.css
 @import "vars";
 @import "../ui-kit/assets/sass/ui-kit.scss";
-@import "components/typography";
+@import "components/*";
 @import "modules/*";


### PR DESCRIPTION
See https://github.com/govCMS/ui-kit-base-theme/issues/25 for discussion and acceptence criteria.

This may not meet our requirements however it does provide tables with a basic style without the need for a particular class.

<img width="861" alt="screen shot 2016-12-19 at 11 02 14 am" src="https://cloud.githubusercontent.com/assets/14192426/21297805/c7e34eb4-c5da-11e6-8b6f-65c02177eedc.png">

It also works with Drupal's sort for tables rendered via views.

<img width="942" alt="screen shot 2016-12-19 at 11 01 36 am" src="https://cloud.githubusercontent.com/assets/14192426/21297811/d5b0189c-c5da-11e6-8aad-b6c53d4e23b6.png">
