### PR TITLE
[content-links] 

### DIFF
--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5891,6 +5891,12 @@ span.ext {
   -webkit-box-sizing: inherit;
           box-sizing: inherit; }
 
+div.toc-filter-content {
+  border: none;
+  background-color: inherit;
+  margin: 0px;
+  padding: 0px; }
+
 div.workbench-info-block {
   padding-left: 1.2em;
   border-left-width: 0.4em;

--- a/sass/modules/_toc_filter.scss
+++ b/sass/modules/_toc_filter.scss
@@ -1,0 +1,6 @@
+div.toc-filter-content {
+  border: none;
+  background-color: inherit;
+  margin: 0px;
+  padding: 0px;
+}

--- a/template.php
+++ b/template.php
@@ -343,6 +343,20 @@ function uikit_base_status_messages($variables) {
   return $output;
 }
 
+/** Contrib Theme functions ***********************************************************/
+
+/**
+ * Implement THEME_toc_filter().
+ */
+function uikit_base_toc_filter($variables) {
+  $output = '<a name="top" class="toc-filter-top"></a>';
+
+  // Add UI KIT content links class.
+  $output .= '<div class="index-links toc-filter toc-filter-' . $variables['type'] . '">';
+  $output .= '<div class="toc-filter-content">' . $variables['content'] . '</div>';
+  $output .= '</div>';
+  return $output;
+}
 
 /** Helper functions **********************************************************/
 


### PR DESCRIPTION
1. Added function to add UI KIT style to table of content. 
2. Added style to override toc_filter default style.

To test:

1. Enable toc_filter module
2. Enable toc_filter in target text format
3. Set up toc_filter module to pick up header tag to generate the table of content
4. Using the target input format to create a node, make sure using the header tag and place [toc] token in the body area
5. View table of content in node view 


