### PR TITLE
An initial simple bootstrap grid using neat

### DIFF
--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -4714,6 +4714,433 @@ article h1:first-of-type, article .hero .site-title:first-of-type, .hero article
       width: 100%;
       border: none; }
 
+.row {
+  display: block; }
+  .row::after {
+    clear: both;
+    content: "";
+    display: table; }
+
+/*
+   * Bootstrap grid - feature
+  */
+@media screen and (min-width: 0) {
+  .col-xs-1 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 5.81604%;
+    padding: 0 0.4em; }
+    .col-xs-1:last-child {
+      margin-right: 0; }
+  .col-xs-2 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 14.37822%;
+    padding: 0 0.4em; }
+    .col-xs-2:last-child {
+      margin-right: 0; }
+  .col-xs-3 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 22.9404%;
+    padding: 0 0.4em; }
+    .col-xs-3:last-child {
+      margin-right: 0; }
+  .col-xs-4 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 31.50258%;
+    padding: 0 0.4em; }
+    .col-xs-4:last-child {
+      margin-right: 0; }
+  .col-xs-5 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 40.06475%;
+    padding: 0 0.4em; }
+    .col-xs-5:last-child {
+      margin-right: 0; }
+  .col-xs-6 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 48.62693%;
+    padding: 0 0.4em; }
+    .col-xs-6:last-child {
+      margin-right: 0; }
+  .col-xs-7 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 57.18911%;
+    padding: 0 0.4em; }
+    .col-xs-7:last-child {
+      margin-right: 0; }
+  .col-xs-8 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 65.75129%;
+    padding: 0 0.4em; }
+    .col-xs-8:last-child {
+      margin-right: 0; }
+  .col-xs-9 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 74.31347%;
+    padding: 0 0.4em; }
+    .col-xs-9:last-child {
+      margin-right: 0; }
+  .col-xs-10 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 82.87564%;
+    padding: 0 0.4em; }
+    .col-xs-10:last-child {
+      margin-right: 0; }
+  .col-xs-11 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 91.43782%;
+    padding: 0 0.4em; }
+    .col-xs-11:last-child {
+      margin-right: 0; }
+  .col-xs-12 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 100%;
+    padding: 0 0.4em; }
+    .col-xs-12:last-child {
+      margin-right: 0; } }
+
+[class*="col-xs"]:first-child {
+  margin-right: 0;
+  padding: 0 0.4em 0 0; }
+
+/*
+   * Bootstrap grid - small
+  */
+@media screen and (min-width: 420px) {
+  .col-sm-1 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 5.81604%;
+    padding: 0 0.4em; }
+    .col-sm-1:last-child {
+      margin-right: 0; }
+  .col-sm-2 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 14.37822%;
+    padding: 0 0.4em; }
+    .col-sm-2:last-child {
+      margin-right: 0; }
+  .col-sm-3 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 22.9404%;
+    padding: 0 0.4em; }
+    .col-sm-3:last-child {
+      margin-right: 0; }
+  .col-sm-4 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 31.50258%;
+    padding: 0 0.4em; }
+    .col-sm-4:last-child {
+      margin-right: 0; }
+  .col-sm-5 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 40.06475%;
+    padding: 0 0.4em; }
+    .col-sm-5:last-child {
+      margin-right: 0; }
+  .col-sm-6 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 48.62693%;
+    padding: 0 0.4em; }
+    .col-sm-6:last-child {
+      margin-right: 0; }
+  .col-sm-7 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 57.18911%;
+    padding: 0 0.4em; }
+    .col-sm-7:last-child {
+      margin-right: 0; }
+  .col-sm-8 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 65.75129%;
+    padding: 0 0.4em; }
+    .col-sm-8:last-child {
+      margin-right: 0; }
+  .col-sm-9 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 74.31347%;
+    padding: 0 0.4em; }
+    .col-sm-9:last-child {
+      margin-right: 0; }
+  .col-sm-10 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 82.87564%;
+    padding: 0 0.4em; }
+    .col-sm-10:last-child {
+      margin-right: 0; }
+  .col-sm-11 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 91.43782%;
+    padding: 0 0.4em; }
+    .col-sm-11:last-child {
+      margin-right: 0; }
+  .col-sm-12 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 100%;
+    padding: 0 0.4em; }
+    .col-sm-12:last-child {
+      margin-right: 0; } }
+
+[class*="col-sm"]:first-child {
+  margin-right: 0;
+  padding: 0 0.4em 0 0; }
+
+/*
+   * Bootstrap grid - medium
+  */
+@media screen and (min-width: 768px) {
+  .col-md-1 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 5.81604%;
+    padding: 0 0.4em; }
+    .col-md-1:last-child {
+      margin-right: 0; }
+  .col-md-2 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 14.37822%;
+    padding: 0 0.4em; }
+    .col-md-2:last-child {
+      margin-right: 0; }
+  .col-md-3 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 22.9404%;
+    padding: 0 0.4em; }
+    .col-md-3:last-child {
+      margin-right: 0; }
+  .col-md-4 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 31.50258%;
+    padding: 0 0.4em; }
+    .col-md-4:last-child {
+      margin-right: 0; }
+  .col-md-5 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 40.06475%;
+    padding: 0 0.4em; }
+    .col-md-5:last-child {
+      margin-right: 0; }
+  .col-md-6 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 48.62693%;
+    padding: 0 0.4em; }
+    .col-md-6:last-child {
+      margin-right: 0; }
+  .col-md-7 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 57.18911%;
+    padding: 0 0.4em; }
+    .col-md-7:last-child {
+      margin-right: 0; }
+  .col-md-8 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 65.75129%;
+    padding: 0 0.4em; }
+    .col-md-8:last-child {
+      margin-right: 0; }
+  .col-md-9 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 74.31347%;
+    padding: 0 0.4em; }
+    .col-md-9:last-child {
+      margin-right: 0; }
+  .col-md-10 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 82.87564%;
+    padding: 0 0.4em; }
+    .col-md-10:last-child {
+      margin-right: 0; }
+  .col-md-11 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 91.43782%;
+    padding: 0 0.4em; }
+    .col-md-11:last-child {
+      margin-right: 0; }
+  .col-md-12 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 100%;
+    padding: 0 0.4em; }
+    .col-md-12:last-child {
+      margin-right: 0; } }
+
+[class*="col-md"]:first-child {
+  margin-right: 0;
+  padding: 0 0.4em 0 0; }
+
+/*
+   * Bootstrap grid - large
+  */
+@media screen and (min-width: 1200px) {
+  .col-lg-1 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 5.81604%;
+    padding: 0 0.4em; }
+    .col-lg-1:last-child {
+      margin-right: 0; }
+  .col-lg-2 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 14.37822%;
+    padding: 0 0.4em; }
+    .col-lg-2:last-child {
+      margin-right: 0; }
+  .col-lg-3 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 22.9404%;
+    padding: 0 0.4em; }
+    .col-lg-3:last-child {
+      margin-right: 0; }
+  .col-lg-4 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 31.50258%;
+    padding: 0 0.4em; }
+    .col-lg-4:last-child {
+      margin-right: 0; }
+  .col-lg-5 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 40.06475%;
+    padding: 0 0.4em; }
+    .col-lg-5:last-child {
+      margin-right: 0; }
+  .col-lg-6 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 48.62693%;
+    padding: 0 0.4em; }
+    .col-lg-6:last-child {
+      margin-right: 0; }
+  .col-lg-7 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 57.18911%;
+    padding: 0 0.4em; }
+    .col-lg-7:last-child {
+      margin-right: 0; }
+  .col-lg-8 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 65.75129%;
+    padding: 0 0.4em; }
+    .col-lg-8:last-child {
+      margin-right: 0; }
+  .col-lg-9 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 74.31347%;
+    padding: 0 0.4em; }
+    .col-lg-9:last-child {
+      margin-right: 0; }
+  .col-lg-10 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 82.87564%;
+    padding: 0 0.4em; }
+    .col-lg-10:last-child {
+      margin-right: 0; }
+  .col-lg-11 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 91.43782%;
+    padding: 0 0.4em; }
+    .col-lg-11:last-child {
+      margin-right: 0; }
+  .col-lg-12 {
+    float: left;
+    display: block;
+    margin-right: 2.74614%;
+    width: 100%;
+    padding: 0 0.4em; }
+    .col-lg-12:last-child {
+      margin-right: 0; } }
+
+[class*="col-lg"]:first-child {
+  margin-right: 0;
+  padding: 0 0.4em 0 0; }
+
 footer section {
   display: table;
   width: 100%; }

--- a/sass/components/_bootstrap-grid-in-neat.scss
+++ b/sass/components/_bootstrap-grid-in-neat.scss
@@ -1,0 +1,42 @@
+$boostrap-grid-columns: 12;
+$boostrap-grid-gutter: $tiny-spacing;
+
+.row {
+  @include row();
+}
+
+$bootstrap-grids: (
+  // name, column-name, media-query
+  // the first media query is a hack so can set `grid-columns` with a !global
+  // @TODO: Turn this into a named map, if possible
+  ("feature", "xs", 0),
+  ("small", "sm", $mobile-minwidth),
+  ("medium", "md", $tablet-minwidth),
+  ("large", "lg", $desktop-minwidth)
+);
+
+@each $bootstrap-name, $bootstrap-col, $bootstrap-media in $bootstrap-grids {
+
+  /*
+   * Bootstrap grid - #{$bootstrap-name}
+  */
+  @media screen and (min-width: $bootstrap-media) {
+    $grid-columns: $boostrap-grid-columns !global;
+    @for $column-number from 1 through $boostrap-grid-columns {
+      .col-#{$bootstrap-col}-#{$column-number} {
+        @include span-columns($column-number of $boostrap-grid-columns);
+        @include pad(0 $boostrap-grid-gutter);
+        // @TODO: Tidy up the output of this, so it only outputs width
+      }
+    }
+  }
+
+  [class*="col-#{$bootstrap-col}"] {
+    &:first-child {
+      @include omega();
+      @include pad(0 $boostrap-grid-gutter 0 0);
+      // @TODO: There must be a better way than setting it to 0
+    }
+  }
+
+}

--- a/sass/components/_bootstrap-grid-in-neat.scss
+++ b/sass/components/_bootstrap-grid-in-neat.scss
@@ -1,5 +1,5 @@
 $boostrap-grid-columns: 12;
-$boostrap-grid-gutter: $tiny-spacing;
+$boostrap-grid-gutter: $tiny-spacing !default;
 
 .row {
   @include row();


### PR DESCRIPTION
This starts to resolve https://github.com/govCMS/ui-kit-base-theme/issues/56

It was written from scratch, looking at the output of Bootstrap.

- It only uses the Neat grid system and inherits any methods it uses
- It has a fixed gutter of `$tiny-spacing`, which you can override by changing or setting your own `$boostrap-grid-gutter`
- It does not support offset, push or pull, it is simple only
- It generates some slightly nasty code duplication for each individual class which is repeated (eg, `.col-md-6` *and* `.col-md-7` both have `float`, `display` and `padding` which could be combined.