### PR TITLE
Pull in Open Sans from Google Fonts

### DIFF
--- a/template.php
+++ b/template.php
@@ -31,6 +31,13 @@ function uikit_base_form_alter(&$form, &$form_state, $form_id) {
 /** Core pre-process functions ************************************************/
 
 /**
+ * Implements THEME_preprocess_html().
+ */
+ function uikit_base_preprocess_html(&$variables) {
+  drupal_add_css('https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700&subset=latin-ext', array('type' => 'external'));
+}
+
+/**
  * Implements THEME_preprocess_field().
  */
 function uikit_base_preprocess_field(&$variables) {


### PR DESCRIPTION
I've gone counter to the [UI toolkit's guidance](http://guides.service.gov.au/design-guide/foundations/typography/index.html) of using [Web Font Loader](https://github.com/typekit/webfontloader). This is because we can implement it in Drupal instead of via JavaScript.

However, this [font selection](https://fonts.google.com/specimen/Open+Sans?selection.family=Open+Sans:400,400i,700), with variations (400, 400 italic, 700 bold) has a 'moderate' load time. It means there is an overhead for the user to download it. It is however a nice font, and hopefully only loaded on from Google Fonts and cached heavily.

#61 

