### PR TITLE
`.element-invisible` was overriding skip link position

### DIFF
--- a/templates/html.tpl.php
+++ b/templates/html.tpl.php
@@ -54,7 +54,7 @@
 </head>
 <body class="<?php print $classes; ?>" <?php print $attributes;?>>
   <nav id="skip-link" class="skip-to">
-    <a href="#main-content" class="element-invisible element-focusable"><?php print t('Skip to main content'); ?></a>
+    <a href="#main-content" class="element-focusable"><?php print t('Skip to main content'); ?></a>
   </nav>
   <?php print $page_top; ?>
   <?php print $page; ?>


### PR DESCRIPTION
When the skip link had `class="element-invisible" it would override some of the positioning that the UI toolkit provided. This meant it was hard against the edge of the page and moved the page around.

The image shows no skip link, current skip link behaviour, skip link fixed by this PR.

![skip-links-moving](https://cloud.githubusercontent.com/assets/13895751/23010522/02183978-f470-11e6-9b11-5d2a9e6cdc31.png)
