### PR TITLE
Add the crest to the footer and enable 'global links'

### DIFF
--- a/template.php
+++ b/template.php
@@ -77,7 +77,6 @@ function uikit_base_preprocess_maintenance_page(&$variables) {
   $variables['header'] = _uikit_base_preprocess_region_header();
 }
 
-
 /**
  * Implements THEME_preprocess_block().
  */
@@ -90,11 +89,12 @@ function uikit_base_preprocess_block(&$variables) {
   $variables['content_attributes_array']['class'] = array('block__content', 'content');
 
   // Global footer links class
-  if($variables['block']->region == 'footer_bottom'){
+  if (
+    $variables['block']->region == 'footer_bottom'
+    && in_array($block->module, array('menu', 'menu_block'))
+  ) {
     $variables['content_attributes_array']['class'][] = 'footer-links';
   }
-
-  $variables['content_attributes_array']['class'] = join(' ', $variables['content_attributes_array']['class']);
 
   // Drupal menu blocks and the Menu Block module's blocks share the same
   // template file to apply the <nav> element.  We also switch template file if

--- a/template.php
+++ b/template.php
@@ -77,6 +77,7 @@ function uikit_base_preprocess_maintenance_page(&$variables) {
   $variables['header'] = _uikit_base_preprocess_region_header();
 }
 
+
 /**
  * Implements THEME_preprocess_block().
  */
@@ -86,7 +87,14 @@ function uikit_base_preprocess_block(&$variables) {
 
   // Add some classes to the block title and content wrapper
   $variables['title_attributes_array']['class'] = 'block__title';
-  $variables['content_attributes_array']['class'] = 'block__content content';
+  $variables['content_attributes_array']['class'] = array('block__content', 'content');
+
+  // Global footer links class
+  if($variables['block']->region == 'footer_bottom'){
+    $variables['content_attributes_array']['class'][] = 'footer-links';
+  }
+
+  $variables['content_attributes_array']['class'] = join(' ', $variables['content_attributes_array']['class']);
 
   // Drupal menu blocks and the Menu Block module's blocks share the same
   // template file to apply the <nav> element.  We also switch template file if

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -112,7 +112,7 @@ elseif ($sidebar_right) {
     <?php endif; ?>
     <section class="footer-bottom">
       <div class="footer-logo">
-        <img alt="Australian Government Coat of Arms" src="<?php print drupal_get_path('theme', 'uikit_base'); ?>/images/coat-of-arms.png">
+        <img alt="<?php print t('Australian Government Coat of Arms');?>" src="<?php print base_path() . drupal_get_path('theme', 'uikit_base'); ?>/images/coat-of-arms.png">
       </div>
       <?php print render($page['footer_bottom']); ?>
     </section>

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -105,9 +105,11 @@ elseif ($sidebar_right) {
 
 <footer role="contentinfo">
   <div class="wrapper">
-    <section class="footer-top">
-      <?php print render($page['footer_top']); ?>
-    </section>
+    <?php if($page['footer_top']): ?>
+      <section class="footer-top">
+        <?php print render($page['footer_top']); ?>
+      </section>
+    <?php endif; ?>
     <section class="footer-bottom">
       <div class="footer-logo">
         <img alt="Australian Government Coat of Arms" src="<?php print drupal_get_path('theme', 'uikit_base'); ?>/images/coat-of-arms.png">

--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -109,6 +109,9 @@ elseif ($sidebar_right) {
       <?php print render($page['footer_top']); ?>
     </section>
     <section class="footer-bottom">
+      <div class="footer-logo">
+        <img alt="Australian Government Coat of Arms" src="<?php print drupal_get_path('theme', 'uikit_base'); ?>/images/coat-of-arms.png">
+      </div>
       <?php print render($page['footer_bottom']); ?>
     </section>
     <section class="page-bottom">


### PR DESCRIPTION
The [UI toolkit specifies](http://guides.service.gov.au/design-guide/patterns/navigation/index.html#footer-navigation) the crest in the footer and 'global links' which are horizontally styled.

To do:

- [x] Add the crest
- [x] Think about the issue when there is too much content it wrap under the crest - part of the UI toolkit
- [x] Remove footer titles - done in config unless anyone has a better suggestion 
- [x] Add `class="footer-links"` to the parent `<div>`
- [x] Remove the empty space if footer-top doesn't have anything in it