### PR TITLE
Remove duplicate ID, improve HTML validation

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -68,7 +68,7 @@ elseif ($sidebar_right) {
 
     <div id="main">
 
-      <div id="content" class="column">
+      <div class="column">
 
         <a href="#skip-link" id="skip-content" class="element-invisible">Go to top of page</a>
 


### PR DESCRIPTION
id="content" is currently declared twice

```
<article id="content" class="content-main">

    <div id="main">

      <div id="content" class="column">
```

This removes it off the div.

Later I'd like to improve:

- The `banner` role is unnecessary for element `header`
- The `main` role is unnecessary for element `main`
- The `contentinfo` role is unnecessary for element `footer`

But these break the UI toolkit, since they rely on them for styling (d'oh).