### PR TITLE
Fix issues where region wrapper was being rendered twice.

### DIFF
--- a/templates/page.tpl.php
+++ b/templates/page.tpl.php
@@ -37,7 +37,7 @@ elseif ($sidebar_right) {
       <?php if ($navigation): ?>
         <div class="site-nav">
           <nav class="site-nav__wrapper">
-            <?php print render($page['navigation']); ?>
+            <?php print $navigation; ?>
           </nav>
         </div>
       <?php endif; ?>
@@ -49,7 +49,7 @@ elseif ($sidebar_right) {
 <?php if ($hero): ?>
   <section class="hero">
     <div class="wrapper">
-      <?php print render($page['hero']); ?>
+      <?php print $hero; ?>
     </div>
   </section>
 <?php endif; ?>


### PR DESCRIPTION
In `page.tpl.php` some regions are being passed through the `render()` function twice.  This is resulting in the theme wrapper function being called twice and duplucate regions being printed.  Results in:

```
<div class="region region-navigation">
  <div class="region region-navigation">
```