### PR TITLE
fix for safari 1px bug in search input group

### DIFF
--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5329,7 +5329,7 @@ form .form-type-radio input[type='radio'] + label {
     border: none; } }
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  .page-header__content form [type=text] {
+  .page-header__content form [type=submit] {
     margin-left: -1px; } }
 
 /**

--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5330,7 +5330,7 @@ form .form-type-radio input[type='radio'] + label {
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   .page-header__content form [type=text] {
-    margin-left: 1px; } }
+    margin-left: -1px; } }
 
 /**
  * This file provides breakpoint information to JS

--- a/css/ui-kit.css
+++ b/css/ui-kit.css
@@ -5328,6 +5328,10 @@ form .form-type-radio input[type='radio'] + label {
     background-image: none;
     border: none; } }
 
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  .page-header__content form [type=text] {
+    margin-left: 1px; } }
+
 /**
  * This file provides breakpoint information to JS
  *

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -161,7 +161,7 @@
 
 //Because Safari can't count
 @media screen and (-webkit-min-device-pixel-ratio:0) {
-  .page-header__content form [type=text] {
+  .page-header__content form [type=submit] {
     margin-left: -1px;
   }
 }

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -159,8 +159,9 @@
   }
 }
 
+//Because Safari can't count
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   .page-header__content form [type=text] {
-    margin-left: 1px;
+    margin-left: -1px;
   }
 }

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -158,3 +158,9 @@
     }
   }
 }
+
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  .page-header__content form [type=text] {
+    margin-left: 1px;
+  }
+}

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -160,6 +160,7 @@
 }
 
 //Because Safari can't count
+// See http://stackoverflow.com/questions/23624265/fixing-1px-bug-in-safari for bug details and fix
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   .page-header__content form [type=submit] {
     margin-left: -1px;


### PR DESCRIPTION
Safari can't count so I have a fix to sort out the gap between the text field and the search  button

<img width="433" alt="screen shot 2017-03-14 at 9 20 14 am" src="https://cloud.githubusercontent.com/assets/14192426/23877690/9748216c-0897-11e7-9d15-88e6bd240ae8.png">
